### PR TITLE
Add `oor` remotes path to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,8 @@ Suggests:
     tmbstan,
     numDeriv,
     parallel
+Remotes:
+    canmod/oor
 LinkingTo:
     TMB,
     RcppEigen,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,6 @@ LinkingTo:
     Rcpp
 VignetteBuilder: 
     knitr
-Additional_repositories: https://canmod.github.io/drat
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ The [Public Health Risk Sciences Division](https://github.com/phac-nml-phrsd) at
 
 ## Installation
 
-Users should install with the following R commands.
+Users should install with the following R command.
 
 ```
-remotes::install_github("canmod/oor")
 remotes::install_github("canmod/macpan2")
 ```
 


### PR DESCRIPTION
This change ensures that `oor` gets installed automatically, so the user doesn't have to manually do `remotes::install_github("oor")` before installing `macpan2`. Not a big issue for users working directly with `macpan2` since they could just follow the old install isntructions in the README (also updated here). However, it gets annoying when building packages that depend on `macpan2`, like [`EPACmodel`](https://github.com/phac-nml-phrsd/EPACmodel), because the `oor` dependecy of `macpan2` would be detected, but there was no path for install. 

Tested this fix in `EPACmodel` by installing it from [here](https://github.com/phac-nml-phrsd/EPACmodel/commit/ec655de9fd472b9e8e1aa5a578c987537df34bc0). It worked!