### PR TITLE
allow 1D layouts

### DIFF
--- a/R/layout-plot-utils.R
+++ b/R/layout-plot-utils.R
@@ -366,7 +366,7 @@ LayoutMatrixGrid = function(spec
       if (length(neighbour) == 1L) layout[min(state_rows), min(state_cols) - 1L] = neighbour
     }
     i = layout != ""
-    return(layout[rowSums(i) > 0L, colSums(i) > 0L])
+    return(layout[rowSums(i) > 0L, colSums(i) > 0L, drop = FALSE])
   }
   
   return_object(self, "LayoutMatrixFactors")


### PR DESCRIPTION
The plotting machinery doesn't work for models where the compartments line up in a single row (admittedly a fairly trivial case, but nice to have it working ...)

This could probably use tests etc.

```r
library(macpan2)
sir_spec <- mp_tmb_library(
         "starter_models"
       , "sir"
       , package = "macpan2"
     )
source(system.file("utils", "box-drawing.R", package = "macpan2"))
mp_layout_grid(sir_spec) |> plot_flow_diagram()
```

> Error in row(layout) : 
  a matrix-like object is required as argument to 'row'

with this branch, we instead get

![sir](https://github.com/user-attachments/assets/11ec4403-12d5-4727-a40f-5f9aeb06d4b5)

