### PR TITLE
test cache test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ To update `src/macpan2` to the state of `misc/dev/dev.cpp` one may run `make src
 
 Running with `misc/dev/dev.cpp` will print out debugging information in a verbose manner, whereas `src/macpan2.cpp` will not. The `src-update` make rule removes the `#define MP_VERBOSE` flag at the top of the file. 
 
-## Make in Windows
+## Developer Installation on Windows
 
 Developers using `make` on Windows, could encounter the following compilation error.
 
@@ -57,3 +57,28 @@ Append the `-Wa,-mbig-obj` flag to the end of this line and save the file. You w
 `CXXFLAGS = -O2 -Wall $(DEBUGFLAG) -mfpmath=sse -msse2 -mstackrealign $(LTO) -Wa,-mbig-obj`
 
 You should now be able to use `make` as described. Note this change might increase the compilation time (~2 min) as described [here](https://github.com/google/googletest/issues/1841#issuecomment-422342176). It would be nice to be able to set this flag globally for all Windows developers. An attempt was made to update the [Makefile](https://github.com/canmod/macpan2/blob/main/Makefile) with this additional line, `CXXFLAGS := $(CXXFLAGS) -Wa,-mbig-obj`, as suggested [here](https://stackoverflow.com/questions/7543978/how-to-pass-g3-flag-to-gcc-via-make-command-line), but it was not successful.
+
+
+## Test Suite
+
+We use the [testthat](https://testthat.r-lib.org/) package. Tests are located [here](tests/testthat/).
+
+To run tests interactively (e.g., in RStudio), please run the following code once in your R session.
+```
+source("tests/testthat/setup.R")
+```
+
+This will load packages that are assumed throughout the test suite and generate a cache of objects that can be (and are) reused in different tests. After running the setup, you can check where the cache got placed by running the following.
+```
+test_cache_dir()
+```
+
+Here is an example of reading in a simulated trajectory of the `infection` variable over five time steps from the library SIR model.
+```
+test_cache_read("TRAJ-sir_5_infection.rds")
+```
+
+To get a list of all objects in the cache.
+```
+test_cache_list()
+```

--- a/inst/utils/test-cache.R
+++ b/inst/utils/test-cache.R
@@ -1,0 +1,18 @@
+test_cache_dir = function() {
+  tools::R_user_dir("macpan2") |> file.path("test_cache")
+}
+test_cache_wipe = function() {
+  test_cache = test_cache_dir()
+  if (!dir.exists(test_cache)) dir.create(test_cache, recursive = TRUE)
+  list.files(test_cache, full.names = TRUE) |> file.remove()
+  return(test_cache)
+}
+test_cache_list = function() {
+  test_cache_dir() |> list.files()
+}
+test_cache_read = function(test_obj_file) {
+  file.path(test_cache_dir(), test_obj_file) |> readRDS()
+}
+test_cache_write = function(obj, test_obj_file) {
+  saveRDS(obj, file.path(test_cache_dir(), test_obj_file))
+}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,4 +1,4 @@
-library(macpan2)
+library(macpan2); library(testthat); library(dplyr); library(tidyr); library(ggplot2)
 system.file("utils", "test-cache.R", package = "macpan2") |> source()
 test_cache = test_cache_wipe()
 all_specs = mp_tmb_entire_library()

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,53 @@
+library(macpan2)
+system.file("utils", "test-cache.R", package = "macpan2") |> source()
+test_cache = test_cache_wipe()
+all_specs = mp_tmb_entire_library()
+
+for (obj in names(all_specs)) {
+  test_cache_write(all_specs[[obj]], sprintf("SPEC-%s.rds", obj))
+}
+
+sims = list(
+    sir_5_infection = mp_simulator(all_specs$sir, 5L, "infection")
+  , sir_5_I = mp_simulator(all_specs$sir, 5L, "I")
+  , sir_5_state = mp_simulator(all_specs$sir, 5L, c("S", "I", "R"))
+  , sir_10_infection = mp_simulator(all_specs$sir, 10L, "infection")
+  , sir_10_I = mp_simulator(all_specs$sir, 10L, "I")
+  , sir_50_infection = mp_simulator(all_specs$sir, 50L, "infection")
+  , sir_50_I = mp_simulator(all_specs$sir, 50L, "I")
+)
+
+for (obj in names(sims)) {
+  test_cache_write(sims[[obj]], sprintf("SIM-%s.rds", obj))
+}
+
+trajs = sapply(sims, mp_trajectory, simplify = FALSE, USE.NAMES = TRUE)
+
+for (obj in names(trajs)) {
+  test_cache_write(trajs[[obj]], sprintf("TRAJ-%s.rds", obj))
+}
+
+cals = list(
+    sir_50_beta_infection = mp_tmb_calibrator(
+        all_specs$sir
+      , data = mp_trajectory(sims$sir_50_infection)
+      , traj = "infection"
+      , par = "beta"
+      , default = list(beta = 0.25)
+    )
+  ## TODO: turn this back on when we merge into a brach with
+  ## implicit transformations on calibrations
+  # , sir_50_log_beta_infection = mp_tmb_calibrator(
+  #       all_specs$sir
+  #     , data = mp_trajectory(sims$sir_50_infection)
+  #     , traj = "infection"
+  #     , par = "log_beta"
+  #     , default = list(beta = 0.25)
+  #   )
+)
+
+for (obj in names(cals)) {
+  test_cache_write(cals[[obj]], sprintf("CAL-%s.rds", obj))
+}
+
+

--- a/tests/testthat/test-calibrator-par.R
+++ b/tests/testthat/test-calibrator-par.R
@@ -1,7 +1,7 @@
 library(macpan2); library(testthat); library(dplyr); library(tidyr); library(ggplot2)
 test_that("bad parameterizations give errors", {
   sir = mp_tmb_library("starter_models", "sir", package = "macpan2")
-  sir_sim = "TRAJ-sir_5_infection.rds" |> test_cache_read()
+  sir_sim = test_cache_read("TRAJ-sir_5_infection.rds")
   
   expect_error(
     mp_tmb_calibrator(sir

--- a/tests/testthat/test-calibrator-par.R
+++ b/tests/testthat/test-calibrator-par.R
@@ -1,7 +1,7 @@
 library(macpan2); library(testthat); library(dplyr); library(tidyr); library(ggplot2)
 test_that("bad parameterizations give errors", {
   sir = mp_tmb_library("starter_models", "sir", package = "macpan2")
-  sir_sim = mp_simulator(sir, time_steps = 5, outputs = c("infection")) |> mp_trajectory()
+  sir_sim = "TRAJ-sir_5_infection.rds" |> test_cache_read()
   
   expect_error(
     mp_tmb_calibrator(sir

--- a/tests/testthat/test-calibrator-traj.R
+++ b/tests/testthat/test-calibrator-traj.R
@@ -5,7 +5,7 @@ test_that("bad outputs give warnings", {
     mp_simulator(sir, time_steps = 5, outputs = c("Infection")),
     regexp = "The following outputs were requested but not available in the model"
   )
-  sir_sims = mp_simulator(sir, time_steps = 5, outputs = c("I")) |> mp_trajectory()
+  sir_sims = "TRAJ-sir_5_I.rds" |> test_cache_read()
   expect_warning(
     mp_tmb_calibrator(sir
       , data = sir_sims
@@ -16,7 +16,7 @@ test_that("bad outputs give warnings", {
     regexp = "The following outputs were requested but not available in the model"
   )
   
-  sir_sim = mp_simulator(sir, time_steps = 5, outputs = c("infection")) |> mp_trajectory()
+  sir_sim = "TRAJ-sir_5_infection.rds" |> test_cache_read()
 
   # doesn't match sir_sim trajectory name
   expect_error(
@@ -41,7 +41,7 @@ test_that("bad outputs give warnings", {
 })
 test_that("trajectories specified with likelihood distributions end up in calibrator outputs", {
   sir = mp_tmb_library("starter_models", "sir", package = "macpan2")
-  sir_sims = mp_simulator(sir, time_steps = 5, outputs = c("S","I","R")) |> mp_trajectory()
+  sir_sims = "TRAJ-sir_5_state.rds" |> test_cache_read()
   
   sir_cal = mp_tmb_calibrator(sir
     , data = sir_sims

--- a/tests/testthat/test-calibrator-tv.R
+++ b/tests/testthat/test-calibrator-tv.R
@@ -49,7 +49,7 @@ test_that("time-varying parameters values on input are consistent with calibrato
 
 test_that("the default value can be changed for the prior standard deviation of rbf coefficients", {
   sir = mp_tmb_library("starter_models", "sir", package = "macpan2")
-  sim = mp_simulator(sir, 10, "I") |> mp_trajectory()
+  sim = "TRAJ-sir_10_I.rds" |> test_cache_read()
   prior_sd_default = 2
   
   cal = mp_tmb_calibrator(sir

--- a/tests/testthat/test-change-model.R
+++ b/tests/testthat/test-change-model.R
@@ -41,7 +41,6 @@ mp_optimize(cal)
 simulator = (spec
   |> mp_hazard()
   |> mp_simulator(10, "infection")
-  #|> mp_trajectory()
 )
 
 args = simulator$tmb_model$make_ad_fun_arg()

--- a/tests/testthat/test-distributions.R
+++ b/tests/testthat/test-distributions.R
@@ -59,7 +59,7 @@ test_that("distributions give appropriate variable assumption warnings", {
     , regexp = "contains zeros at the beginning of the simulation"
   )
   
-  data = mp_simulator(sir_spec, 50, "infection") |> mp_trajectory()
+  data = "TRAJ-sir_50_infection.rds" |> test_cache_read()
   expect_error(
     mp_tmb_calibrator(
         sir_spec
@@ -78,7 +78,7 @@ test_that("you can specify uniform priors but not uniform likelihoods", {
     , "sir"
     , package = "macpan2"
   )
-  sir_sim = mp_simulator(sir_spec, 10, "I") |> mp_trajectory()
+  sir_sim = "TRAJ-sir_50_I.rds" |> test_cache_read()
   
   # uniform likelihood
   expect_error(mp_tmb_calibrator(sir_spec


### PR DESCRIPTION
Cache objects that are used repeatedly throughout the tests.  I don't love doing this because it makes things less readable, which is the last thing you want in a test suite.  But the test performance is starting to be an issue.